### PR TITLE
Refactoring to support payloads

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,0 @@
-options:
-  repository_configuration:
-    type: string
-    default:
-    description: |
-        Repository to clone for the build workspace configuration. assumes
-        directory tree starts from the `/var/lib/jenkins/jobs` path.

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,1 +1,4 @@
-includes: ['layer:basic']  # if you use any interfaces, add them here
+includes: 
+  - 'layer:basic'
+  - 'interface:juju-info' 
+repo: https://github.com/juju-solutions/layer-kubernetes-builder.git

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,3 +11,10 @@ subordinate: true
 requires:
   jenkins-host:
     interface: juju-info
+    scope: container
+resources:
+  workspace:
+    type: file
+    filename: workspace.zip
+    description: |
+        Directory Tree warehoused in the BUILD directory: /var/lib/jenkins/jobs/$WORKSPACE

--- a/reactive/kubernetes_builder.sh
+++ b/reactive/kubernetes_builder.sh
@@ -3,6 +3,7 @@ set -ex
 
 source charms.reactive.sh
 
+JENKINS_WORKSPACE_DIR=/var/lib/jenkins/jobs
 
 @when_not 'kubernetes-builder workload_builder.configured'
 function install_kubernetes-builder() {
@@ -41,8 +42,8 @@ function deliver_resource_payload() {
   fi
 
   if [ ! -z "${WORKSPACEZIP}" ]; then
-     cp $WORKSPACEZIP /var/lib/jenkins/jobs/delivery.zip
-     cd /var/lib/jenkins/jobs
+     cp $WORKSPACEZIP $JENKINS_WORKSPACE_DIR/delivery.zip
+     cd $JENKINS_WORKSPACE_DIR
      unzip delivery.zip
      rm delivery.zip
      chown -R jenkins:jenkins *


### PR DESCRIPTION
After much internal debate about how to deliver the workspace... this
really makes sense as personally provided payload. There is room for
improvement here, as there is no support for sniffing zero byte files
for the dummy payload.

to exercise:

```
 juju attach kubernetes-builder workspace=./workspace.zip
```